### PR TITLE
Insert four_o_four in a higher level within the middleware's stack.

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ application. On rails can be done like this:
 module YourAwesomeApp
   class Application < Rails::Application
     # .... extra configuration
-    config.middleware.use 'FourOFour'
+    config.middleware.insert_before ActionDispatch::RemoteIp, FourOFour
   end
 end
 ```
@@ -59,7 +59,7 @@ parameter to the configuration...
 module YourAwesomeApp
   class Application < Rails::Application
     # .... extra configuration
-    config.middleware.use 'FourOFour', 'DelegatedClass'
+    config.middleware.insert_before ActionDispatch::RemoteIp, FourOFour, 'DelegatedClass'
   end
 end
 ```


### PR DESCRIPTION
Since the gem is catching the header format, we should not need all the other middleware process.
I could not set it higher because the `params` helper in controllers still need to eventually be accessible during the response.